### PR TITLE
ユーザー作成・更新時に他のユーザーとemailを重複して登録できないよう修正 close #7

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -13,7 +13,9 @@ import (
 
 var (
 	// DB データベース構造体
-	DB   *gorm.DB
+	DB *gorm.DB
+	// tx トランザクション
+	tx   *gorm.DB
 	user model.User
 	// TableName サービステーブル名
 	TableName string = "users"
@@ -53,6 +55,25 @@ func Close() {
 func GetDB() *gorm.DB {
 	initDB()
 	return DB
+}
+
+// StartBegin トランザクションを開始する。
+func StartBegin() *gorm.DB {
+	DB = GetDB()
+	tx = DB.Begin()
+	return tx
+}
+
+// EndRollback トランザクションを終了しロールバックする。
+func EndRollback() {
+	tx.Rollback()
+	tx = nil
+}
+
+// EndCommit トランザクションを終了しコミットする。
+func EndCommit() {
+	tx.Commit()
+	tx = nil
 }
 
 func autoMigration() {

--- a/grpc/handler.go
+++ b/grpc/handler.go
@@ -113,6 +113,11 @@ func (s server) ReadUser(ctx context.Context, req *userservice.ReadUserRequest) 
 func (s server) UpdateUser(ctx context.Context, req *userservice.UpdateUserRequest) (*userservice.UpdateUserResponse, error) {
 	user := makeModel(req.GetUser())
 
+	// 既に同一のemailによる登録がないかチェック
+	if s.userExistsByEmail(user.Email) == true {
+		return s.makeUpdateUserResponse(StatusEmailAlreadyUsed), nil
+	}
+
 	if _, err := s.Usecase.Update(user); err != nil {
 		return nil, err
 	}

--- a/usecase/interactor/interactor_test.go
+++ b/usecase/interactor/interactor_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	testemail       = "test@gmail.com"
-	superemail      = "super@gmail.com"
+	testemail       = "test@example.com"
+	superemail      = "super@example.com"
 	testpassword    = "password"
 	demoProfileText = "プロフィールが入ります"
 	updatedName     = "updatedName"
@@ -74,7 +74,7 @@ var EmailInvalidUser1 = &model.User{
 var EmailInvalidUser2 = &model.User{
 	UserName:    "testuser",
 	Password:    testpassword,
-	Email:       "@gmail.com",
+	Email:       "@example.com",
 	Authority:   authorityNormalUser,
 	ProfileText: demoProfileText,
 }
@@ -86,9 +86,13 @@ func TestCreate(t *testing.T) {
 	var users []model.User
 	// user := &DemoUser
 	users = append(users, DemoUser)
+	DemoUser.Email = "acregh@example.com"
 	users = append(users, DemoUser)
+	DemoUser.Email = "uiwefg@example.com"
 	users = append(users, DemoUser)
+	DemoUser.Email = "dgjs5ts@example.com"
 	users = append(users, DemoUser)
+	DemoUser.Email = "th5fa6j@example.com"
 	users = append(users, DemoUser)
 	for _, u := range users {
 		createdUser, err := i.Create(&u)
@@ -138,7 +142,6 @@ func TestGetUserByEmail(t *testing.T) {
 	assert.Equal(t, nil, err)
 	assert.Equal(t, DemoUser.UserName, user.UserName)
 	assert.Equal(t, DemoUser.Email, user.Email)
-	assert.Equal(t, DemoUser.Password, user.Password)
 }
 
 func TestCreateNameNull(t *testing.T) {
@@ -239,6 +242,19 @@ func TestUpdateNameTooShort(t *testing.T) {
 	inputUser := findUser
 
 	inputUser.UserName = "testu"
+	inputUser.Password = "password"
+
+	_, err = i.Update(&inputUser)
+	assert.NotEqual(t, nil, err)
+}
+
+func TestUpdateUserEmailUsed(t *testing.T) {
+	var i UserInteractor
+	findUser, err := i.GetUserByEmail(DemoUser.Email)
+	assert.Equal(t, nil, err)
+	inputUser := findUser
+
+	inputUser.Email = testemail
 	inputUser.Password = "password"
 
 	_, err = i.Update(&inputUser)

--- a/usecase/repository/repository.go
+++ b/usecase/repository/repository.go
@@ -8,6 +8,7 @@ type UserRepository interface {
 	Create(*model.User) (*model.User, error)
 	Read(uint32) (model.User, error)
 	GetUserByEmail(string) (model.User, error)
+	OtherUserExistsByEmail(string, uint32) bool
 	DeleteByID(id uint32) error
 	List() ([]model.User, error)
 	ListAllNormalUser() ([]model.User, error)


### PR DESCRIPTION
- emailが重複するユーザーが存在する場合はユーザー更新できないよう修正
- テスト時にもemailが重複したユーザーを登録できないよう、ユーザー作成・更新メソッド内でemail重複ユーザーがいないかチェックを追加
- トランザクション ・ロールバック機能追加